### PR TITLE
Updated Readme to correct the installation behaviour

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Modified CPU checking instruction for DS213J (Marvel Armada-370).
 ## Install
 root login into DS213J
 ```
-$ /usr/syno/bin/wget https://github.com/hsleep/ds213j_bootstrap/archive/master.zip --no-check-certificate
+$ /usr/syno/bin/wget https://github.com/hsleep/ds213j_bootstrap/archive/master.zip --no-check-certificate -O ds213j_bootstrap-master.zip
 $ unzip ds213j_bootstrap-master.zip
 $ cd ds213j_bootstrap-master
 $ sh bootstrap.sh


### PR DESCRIPTION
The installation instruction expected that the zipfile was **ds213j_bootstrap-master.zip** but **master.zip** was created.

This PR corrects the installation process.
